### PR TITLE
Add a tag execution command to define a new standard HashType represe…

### DIFF
--- a/txscript/scriptcmd.go
+++ b/txscript/scriptcmd.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2018-2020 The Hc developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txscript
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/HcashOrg/hcd/chaincfg"
+	"github.com/HcashOrg/hcd/chaincfg/chainhash"
+	"github.com/HcashOrg/hcd/wire"
+)
+
+// SigHashType represents hash type bits at the end of a signature.
+type SigHashType byte
+
+// Hash type bits from the end of a signature.
+const (
+	SigHashOld          SigHashType = 0x0
+	SigHashAll          SigHashType = 0x1
+	SigHashNone         SigHashType = 0x2
+	SigHashSingle       SigHashType = 0x3
+	SigHashAllValue     SigHashType = 0x4
+	SigHashAnyOneCanPay SigHashType = 0x80
+
+	// sigHashMask defines the number of bits of the hash type which is used
+	// to identify which outputs are signed.
+	sigHashMask = 0x1f
+)
+
+// These are the constants specified for maximums in individual scripts.
+const (
+	MaxOpsPerScript       = 255  // Max number of non-push operations.
+	MaxPubKeysPerMultiSig = 20   // Multisig can't have more sigs than this.
+	MaxScriptElementSize  = 4096 // Max bytes pushable to the stack.
+)
+

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -13,6 +13,25 @@ import (
 	"testing"
 )
 
+//  swaps the top  items on the stack with those below them
+func (s *stack) SwapNTest(n int32) error {
+	if n < 1 {
+		return ErrStackInvalidArgs
+	}
+
+	entry := 2*n - 1
+	for i := n; i > 0; i-- {
+		// Swap 2n-1th entry to top.
+		so, err := s.nipN(entry)
+		if err != nil {
+			return err
+		}
+
+		s.PushByteArray(so)
+	}
+	return nil
+}
+
 // TestStack tests that all of the stack operations work as expected.
 func TestStack(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
…ntation   hashType represents hash type bits at the end of a signature

Add a tag execution command to define a new standard HashType representation   hashType represents hash type bits at the end of a signature